### PR TITLE
Query and Scala parser for DevSearch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 .idea/
+*.swp

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,8 @@ version := "0.1"
 
 scalaVersion := "2.10.4"
 
+scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
+
 resolvers ++= Seq(
   Resolver.sonatypeRepo("releases"),
   Resolver.sonatypeRepo("snapshots")

--- a/build.sbt
+++ b/build.sbt
@@ -29,3 +29,5 @@ libraryDependencies ++= Seq(
   "com.github.nikita-volkov" % "sext" % "0.2.3",
   "org.apache.spark" %% "spark-core" % "1.3.0"
 )
+
+parallelExecution in Test := false

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ libraryDependencies ++= Seq(
 libraryDependencies ++= Seq(
   "com.github.javaparser" % "javaparser-core" % "2.0.0",
   "com.chuusai" % "shapeless_2.10.4" % "2.0.0",
+  "org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.full,
   "io.spray" %%  "spray-json" % "1.3.1"
 )
 

--- a/src/main/scala/devsearch/ast/Source.scala
+++ b/src/main/scala/devsearch/ast/Source.scala
@@ -21,14 +21,18 @@ trait Source extends Serializable {
     indexes(0, Nil).reverse
   }
 
-  def position(offset: Int) = {
+  def offsetCoords(offset: Int) = {
     def extractPosition(offset: Int, line: Int, sizes: List[Int]): (Int, Int) = sizes match {
       case lineSize :: xs =>
         if (offset < lineSize) (line, offset)
         else extractPosition(offset - lineSize, line + 1, xs)
       case _ => (offset, line)
     }
-    val (line, col) = extractPosition(offset, 0, lineSizes)
+    extractPosition(offset, 0, lineSizes)
+  }
+
+  def position(offset: Int) = {
+    val (line, col) = offsetCoords(offset)
     SimplePosition(this, line, col)
   }
 

--- a/src/main/scala/devsearch/parsers/QueryParser.scala
+++ b/src/main/scala/devsearch/parsers/QueryParser.scala
@@ -1,0 +1,541 @@
+package devsearch.parsers
+
+import devsearch.ast
+import devsearch.ast.{Source, Names, AST}
+
+import scala.tools.nsc.interactive._
+import scala.tools.nsc.ast.parser.{Parsers => ScalaParser}
+import scala.reflect.internal.util.{Position => _, _}
+
+import org.scalamacros.paradise.parser.Tokens._
+import org.scalamacros.paradise.quasiquotes._
+
+object QueryParser extends Parser {
+
+  private lazy val compiler = {
+    val settings = new scala.tools.nsc.Settings
+    val scalaLib = Option(scala.Predef.getClass.getProtectionDomain.getCodeSource).map(_.getLocation.getPath).getOrElse {
+      throw ParsingFailedError(new RuntimeException("couldn't find scala library"))
+    }
+
+    settings.classpath.value = scalaLib
+    settings.usejavacp.value = false
+
+    new scala.tools.nsc.interactive.Global(settings, new scala.tools.nsc.reporters.Reporter {
+      def info0(pos: scala.reflect.internal.util.Position, msg: String, severity: Severity, force: Boolean) = ()
+    })
+  }
+
+  private lazy val queryCompiler = new QueryCompiler
+
+  def parse(source: Source): AST = try {
+    queryCompiler.parse(source)
+  } catch {
+    case abort: scala.reflect.macros.runtime.AbortMacroException => throw ParsingFailedError(abort)
+  }
+
+  private class QueryCompiler extends {
+    val c = new {
+      val universe: compiler.type = compiler
+      val expandee = universe.EmptyTree
+      val callsiteTyper = universe.analyzer.newTyper(universe.analyzer.NoContext)
+    } with scala.reflect.macros.runtime.Context {
+      val prefix = Expr[Nothing](universe.EmptyTree)(TypeTag.Nothing)
+    }
+  } with Quasiquotes { self =>
+
+    import global._
+    import compat.{gen, build}
+    import build.implodePatDefs
+
+    object parser extends Parser {
+      def entryPoint = parser => Q(implodePatDefs(gen.mkTreeOrBlock(parser.templateOrTopStatSeq())))
+
+      // Quick fix to make sure we have range positions everywhere even if they don't make sense...
+      // Without this, we get crashes in the Paradise parser in TreeGen.mkFor where range positions are expected
+      override lazy val compat = new { val global: compiler.type = compiler } with scala.quasiquotes.SymbolTableCompat {
+        override lazy val gen = new { val global: compiler.type = compiler } with scala.quasiquotes.TreeGen {
+          import global._
+          override def mkFor(enums: List[Tree], sugarBody: Tree)(implicit fresh: quasiquotes.FreshNameCreator): Tree = {
+            def rangePos(t: Tree): t.type = t.pos match {
+              case NoPosition => t
+              case range: RangePosition => t
+              case p => t.setPos(new RangePosition(p.source, p.point, p.point, p.point))
+            }
+            rangePos(super.mkFor(enums.map(rangePos(_)), sugarBody))
+          }
+        }
+      }
+
+      def parse(source: SourceFile): Tree = {
+        try {
+          scala.util.Try {
+            val parser = new HoleParser(source)
+            parser.checkNoEscapingPlaceholders { parser.parseRule(entryPoint) }
+          }.orElse(scala.util.Try {
+            new HoleParser(source).compilationUnit()
+          }).get
+        } catch {
+          case mi: MalformedInput =>
+            if (posMap.isEmpty) c.abort(NoPosition, "Unparsable stuff: " + mi.msg)
+            else c.abort(correspondingPosition(mi.offset), mi.msg)
+        }
+      }
+
+      class HoleParser(source0: SourceFile) extends QuasiquoteParser(source0) {
+        lazy val dfltName = newTermName(Names.DEFAULT)
+
+        object dummyHole extends Hole {
+          val tree = EmptyTree
+          val pos = NoPosition
+          val rank = Rank.NoDot
+        }
+
+        holeMap.update(c.fresh[TermName]("_"), dummyHole)
+
+        override def isHole: Boolean = in.token == USCORE
+        override def isHole(name: Name): Boolean = name.toString == "_"
+
+        override def ident(skipIt: Boolean): Name =
+          if (in.name.toString == "_") {
+            in.nextToken()
+            dfltName 
+          } else super.ident(skipIt)
+      }
+    }
+
+    object Normalizer extends (ast.AST => ast.AST) {
+
+      private object PrimitiveExtractor {
+        def unapply(tpe: ast.Type): Option[String] = tpe match {
+          case ast.ClassType(ast.Ident("scala"), name, Nil, Nil) => Some(name)
+          case ast.ClassType(ast.Empty.NoExpr, name, Nil, Nil) => Some(name)
+          case _ => None
+        }
+      }
+
+      private val FUNCTION_NAME: String = tpnme.QUASIQUOTE_FUNCTION.toString
+      private def isOperator(op: String): Boolean = op != newTermName(op).encode.toString
+
+      def apply(a: ast.AST): ast.AST = a.transform {
+        case PrimitiveExtractor("Unit") => Some(ast.PrimitiveTypes.Void)
+        case PrimitiveExtractor("String") => Some(ast.PrimitiveTypes.String)
+        case PrimitiveExtractor("Boolean") => Some(ast.PrimitiveTypes.Boolean)
+        case PrimitiveExtractor("Char") => Some(ast.PrimitiveTypes.Char)
+        case PrimitiveExtractor("Byte") => Some(ast.PrimitiveTypes.Byte)
+        case PrimitiveExtractor("Short") => Some(ast.PrimitiveTypes.Short)
+        case PrimitiveExtractor("Int") => Some(ast.PrimitiveTypes.Int)
+        case PrimitiveExtractor("Long") => Some(ast.PrimitiveTypes.Long)
+        case PrimitiveExtractor("Float") => Some(ast.PrimitiveTypes.Float)
+        case PrimitiveExtractor("Double") => Some(ast.PrimitiveTypes.Double)
+        case ct @ ast.ClassType(ast.Empty.NoExpr, FUNCTION_NAME, Nil, tparams) if tparams.nonEmpty =>
+          Some(ast.FunctionType(tparams.init, tparams.last).fromAST(ct))
+        case fc @ ast.FunctionCall(ast.FieldAccess(e1, op, Nil), Nil, List(e2)) if isOperator(op) =>
+          if (op.endsWith("=")) {
+            val init: String = op.init
+            Some(ast.Assign(e1, e2, if (init != "") Some(init) else None).fromAST(fc))
+          } else Some(ast.BinaryOp(e1, op, e2).fromAST(fc))
+        case _ => None
+      }
+    }
+
+    def parse(source: Source) = {
+      val sourceFile = new scala.reflect.internal.util.BatchSourceFile(NoFile, source.contents)
+      val tree = parser.parse(sourceFile)
+
+      def extractPosition(pos: Position): ast.Position = pos match {
+        case r: RangePosition =>
+          val (startLine,startCol) = source.offsetCoords(r.start)
+          val (endLine,endCol) = source.offsetCoords(r.end)
+          source.position(startLine, startCol, endLine, endCol)
+        case NoPosition => source.position(0)
+        case _ => source.position(pos.point)
+      }
+
+      def extractName(tree: Tree): String = tree match {
+        case r: RefTree => extractName(r.qualifier) match {
+          case "" => r.name.decode
+          case q => q + "." + r.name.decode
+        }
+        case EmptyTree => ""
+        case _ => tree.toString
+      }
+
+      def extractModifiers(mods: Modifiers, pos: ast.Position): (ast.Modifiers, List[ast.Annotation]) = {
+        import ast.Modifiers
+        import Modifiers.NoModifiers
+
+        val modifiers = (if (mods.hasFlag(Flag.PROTECTED)) Modifiers.PROTECTED else NoModifiers) |
+          (if (mods.privateWithin != tpnme.EMPTY || mods.hasFlag(Flag.PRIVATE)) Modifiers.PRIVATE else NoModifiers) |
+          (if (mods.hasFlag(Flag.FINAL) || !mods.hasFlag(Flag.MUTABLE)) Modifiers.FINAL else NoModifiers) |
+          (if (mods.hasFlag(Flag.DEFERRED) || mods.hasFlag(Flag.ABSTRACT)) Modifiers.ABSTRACT else NoModifiers)
+
+        val annots = (if (mods.hasFlag(Flag.OVERRIDE))
+            List(ast.Annotation(Names.OVERRIDE_ANNOTATION).setPos(pos))
+          else
+            Nil) ++ mods.annotations.flatMap(a => extractExpr(a) match {
+              case _ => Nil
+            })
+
+        (modifiers, annots)
+      }
+
+      def extractTypeDef(td: TypeDef): ast.TypeDef = {
+        val name = td.name.decode
+        val pos = extractPosition(td.pos)
+        val tparams = td.tparams.map(extractTypeDef)
+        val (modifiers, annotations) = extractModifiers(td.mods, pos)
+        td.rhs match {
+          case TypeBoundsTree(lo, hi) =>
+            val (low, high) = (extractType(lo), extractType(hi))
+            ast.TypeDef(modifiers, name, annotations, tparams, List(low), List(high)).setPos(pos)
+          case tpt =>
+            ast.TypeDef(modifiers, name, annotations, tparams, Nil, List(extractType(tpt))).setPos(pos)
+        }
+      }
+
+      def extractTemplate(template: Template): (List[ast.Type], List[ast.Definition], List[ast.Statement]) = {
+        val parents = template.parents.map(extractType)
+        val selfTpes = if (template.self.name == nme.WILDCARD && template.self.tpt == NoType) Nil else {
+          val vd = extractDef(template.self).asInstanceOf[ast.ValDef]
+          List(vd.copy(modifiers = vd.modifiers | ast.Modifiers.PRIVATE | ast.Modifiers.FINAL))
+        }
+        val body = template.body.flatMap(extractStmts)
+        val (definitions, statements) = body.partition(_.isInstanceOf[ast.Definition])
+        (parents, selfTpes ++ definitions.map(_.asInstanceOf[ast.Definition]), statements)
+      }
+
+      def wrapStatements(asts: List[ast.Statement]): ast.Block = asts match {
+        case Nil => ast.Empty.NoStmt
+        case (b: ast.Block) :: Nil => b
+        case stmts => ast.Block(stmts).setPos(stmts.head.pos)
+      }
+
+      def extractType(tpt: Tree): ast.Type = {
+        val pos = extractPosition(tpt.pos)
+
+        val extracted = tpt match {
+          case TypeTree() => ast.Empty.NoType
+
+          case Ident(name) =>
+            if (name.decode == Names.DEFAULT) ast.Empty.NoType
+            else ast.ClassType(ast.Empty.NoExpr, name.decode, Nil, Nil)
+
+          case Select(scope, name) =>
+            ast.ClassType(extractExpr(scope), name.decode, Nil, Nil)
+
+          case AppliedTypeTree(tpt, args) => extractType(tpt) match {
+            case ct @ ast.ClassType(scope, name, annotations, params) =>
+              ast.ClassType(scope, name, annotations, params ++ args.map(extractType)).fromAST(ct)
+            case tpe => tpe.appendComment(args.map(_.toString).mkString("[",",","]"))
+          }
+
+          case CompoundTypeTree(templ) =>
+            val (parents, defs, init) = extractTemplate(templ)
+            ast.ComplexType(parents, defs, ast.Empty.NoExpr)
+
+          case SingletonTypeTree(tpe) =>
+            ast.ComplexType(Nil, Nil, extractExpr(tpe))
+
+          case ExistentialTypeTree(tpt, clauses) =>
+            ast.ComplexType(extractType(tpt) :: Nil, clauses.map(extractDef), ast.Empty.NoExpr)
+
+          case SelectFromTypeTree(qualifier, name) =>
+            val pos = extractPosition(tree.pos)
+            ast.ComplexType(extractType(qualifier) :: Nil, Nil, ast.Ident(name.decode).setPos(pos))
+
+          case Annotated(annot, arg) =>
+            extractType(arg).appendComment(annot.toString)
+
+          case o => throw ParsingFailedError(new RuntimeException(s"Unknown type tree [${o.getClass}]: $o"))
+        }
+
+        extracted.setPos(pos)
+      }
+
+      def extractDef(tree: Tree): ast.Definition = {
+        val pos = extractPosition(tree.pos)
+
+        val extracted: ast.Definition = tree match {
+          case PackageDef(pid, stats) =>
+            val (imports, defs) = stats.flatMap(extractStmts).partition(_.isInstanceOf[ast.Import])
+            ast.PackageDef(extractName(pid), Nil, imports.map(_.asInstanceOf[ast.Import]), defs.map(_.asInstanceOf[ast.Definition]))
+
+          case ClassDef(mods, name, tparams, impl) =>
+            val sort = if (mods.hasFlag(Flag.TRAIT) || mods.hasFlag(Flag.INTERFACE)) ast.TraitSort else ast.ClassSort
+            val (modifiers, annotations) = extractModifiers(mods, pos)
+            val (parentTypes, definitions, body) = extractTemplate(impl)
+            val parents = parentTypes.collect { case tpe : ast.ClassType => tpe }
+            val init = if (body.isEmpty) Nil else List(ast.Initializer(false, Nil, ast.Block(body).setPos(pos)).setPos(pos))
+            ast.ClassDef(modifiers, name.decode, annotations, tparams.map(extractTypeDef), parents, init ++ definitions, sort)
+
+          case ModuleDef(mods, name, impl) =>
+            val (modifiers, annotations) = extractModifiers(mods, pos)
+            val (parentTypes, definitions, body) = extractTemplate(impl)
+            val parents = parentTypes.collect { case tpe : ast.ClassType => tpe }
+
+            val init = if (body.isEmpty) Nil else List(ast.Initializer(true, Nil, ast.Block(body).setPos(pos)).setPos(pos))
+            val staticDefs = init ++ definitions.map {
+              case cd: ast.ClassDef => cd.copy(modifiers = cd.modifiers | ast.Modifiers.STATIC).fromAST(cd)
+              case fd: ast.FunctionDef => fd.copy(modifiers = fd.modifiers | ast.Modifiers.STATIC).fromAST(fd)
+              case vd: ast.ValDef => vd.copy(modifiers = vd.modifiers | ast.Modifiers.STATIC).fromAST(vd)
+              case d => d
+            }
+            ast.ClassDef(modifiers | ast.Modifiers.FINAL, name.decode, annotations, Nil, parents, staticDefs)
+
+          case build.SyntacticPatDef(mods, pat, tpt, rhs) =>
+            val (modifiers, annotations) = extractModifiers(mods, pos)
+            val pattern = extractExpr(pat)
+            val value = extractExpr(rhs)
+            extractType(tpt) match {
+              case ast.Empty.NoType => ast.ExtractionValDef(modifiers, pattern, annotations, value)
+              case tpe => ast.ExtractionValDef(modifiers, ast.InstanceOf(pattern, tpe).setPos(pattern.pos), annotations, value)
+            }
+
+          case ValDef(mods, name, tpt, rhs) =>
+            val (modifiers, annotations) = extractModifiers(mods, pos)
+            val (tpe, varArgs) = extractType(tpt) match {
+              case ast.ClassType(ast.FieldAccess(ast.Ident("_root_"), "scala", Nil), "<repeated>", Nil, List(tpe)) =>
+                (tpe, true)
+              case tpe =>
+                (tpe, false)
+            }
+            ast.ValDef(modifiers, name.decode, annotations, tpe, extractExpr(rhs), varArgs)
+
+          case DefDef(mods, name, tparams, vparamss, tpt, rhs) =>
+            val (modifiers, annotations) = extractModifiers(mods, pos)
+            val params = vparamss.flatten.map(vd => extractDef(vd).asInstanceOf[ast.ValDef])
+            val body = wrapStatements(extractStmts(rhs))
+            ast.FunctionDef(modifiers, name.decode, annotations, tparams.map(extractTypeDef), params, extractType(tpt), body)
+
+          case td @ TypeDef(mods, name, tparams, rhs) => extractTypeDef(td)
+
+          case o => throw ParsingFailedError(new RuntimeException(s"Unknown definition tree [${o.getClass}]: $o"))
+        }
+
+        extracted.setPos(pos)
+      }
+
+      def extractStmts(tree: Tree): List[ast.Statement] = {
+        val pos = extractPosition(tree.pos)
+
+        val extracted: List[ast.Statement] = tree match {
+          case Import(expr, selectors) =>
+            val name = extractName(expr)
+            selectors.map { s =>
+              val (path, asterisk) = if (s.name == nme.WILDCARD) {
+                (name, true)
+              } else {
+                (name + "." + s.name, false)
+              }
+              ast.Import(path, asterisk, true)
+            }
+
+          case Apply(fun, args) => List(extractExpr(fun) match {
+            case a @ ast.FieldAccess(s @ ast.Super(qual), nme.CONSTRUCTOR, tparams) =>
+              val call = ast.SuperCall(qual, tparams, args.map(extractExpr)).fromAST(a)
+              s.comment.foreach(call.appendComment)
+              call
+            case a @ ast.FieldAccess(s @ ast.This(qual), nme.CONSTRUCTOR, tparams) =>
+              val call = ast.ThisCall(qual, tparams, args.map(extractExpr)).fromAST(a)
+              s.comment.foreach(call.appendComment)
+              call
+            case _ => extractExpr(tree)
+          })
+
+          case LabelDef(nm1, _, If(cond, Block(stats, Apply(Ident(nm2), Nil)), _)) if nm1 == nm2 =>
+            List(ast.While(extractExpr(cond), wrapStatements(stats.flatMap(extractStmts))))
+
+          case LabelDef(nm1, _, Block(stats, If(cond, Apply(Ident(nm2), Nil), _))) if nm1 == nm2 =>
+            List(ast.Do(extractExpr(cond), wrapStatements(stats.flatMap(extractStmts))))
+
+          case ld : LabelDef => throw ParsingFailedError(new RuntimeException(s"Unexpected label-def: $ld"))
+
+          case t: TermTree => extractExpr(t) match {
+            case ast.Empty.NoExpr => Nil
+            case expr => List(expr)
+          }
+
+          case r: RefTree => extractExpr(r) match {
+            case ast.Empty.NoExpr => Nil
+            case expr => List(expr)
+          }
+
+          case d: DefTree => extractDef(d) match {
+            case ast.Empty.NoDef => Nil
+            case definition => List(definition)
+          }
+
+          case Annotated(annot, arg) =>
+            extractStmts(arg) match {
+              case x :: xs => x.appendComment(annot.toString) :: xs
+              case _ => Nil
+            }
+
+          case o => throw ParsingFailedError(new RuntimeException(s"Unknown statement tree [${o.getClass}]: $o"))
+        }
+
+        extracted.map(_.setPos(pos))
+      }
+
+      def extractExpr(tree: Tree): ast.Expr = {
+        val pos = extractPosition(tree.pos)
+
+        def extractFors(enums: List[Tree], body: ast.Expr, generator: Boolean): ast.Expr = enums match {
+          case Nil => body
+          case Apply(Ident(nme.LARROWkw), Bind(name, expr) :: iterable :: Nil) :: xs =>
+            val inner = extractFors(xs, body, generator)
+            val valDef = ast.ValDef(ast.Modifiers.FINAL, name.decode, Nil, ast.Empty.NoType, ast.Empty.NoExpr)
+            expr match {
+              case Ident(nme.WILDCARD) =>
+                ast.Foreach(valDef :: Nil, extractExpr(iterable), inner, generator)
+              case _ =>
+                val extractor = ast.ExtractionValDef(ast.Modifiers.FINAL, extractExpr(expr), Nil, ast.Empty.NoExpr)
+                val block = inner match {
+                  case ast.Block(stmts) => ast.Block(extractor :: stmts).fromAST(inner)
+                  case stmt => ast.Block(extractor :: stmt :: Nil).fromAST(inner)
+                }
+                ast.Foreach(valDef :: Nil, extractExpr(iterable), block, generator)
+            }
+          case (a @ Assign(e1, e2)) :: xs =>
+            val inner = extractFors(xs, body, generator)
+            val rhs = extractExpr(e2)
+            ast.Block(List(extractExpr(e1) match {
+              case b @ ast.Bind(name, ast.Wildcard) =>
+                ast.ValDef(ast.Modifiers.FINAL, name, Nil, ast.Empty.NoType, rhs).fromAST(b)
+              case expr =>
+                ast.ExtractionValDef(ast.Modifiers.FINAL, expr, Nil, rhs).fromAST(expr)
+            }, inner)).setPos(extractPosition(a.pos))
+
+          case _ :: xs => extractFors(xs, body, generator)
+        }
+
+        val extracted: ast.Expr = tree match {
+          case Block(stats, expr) =>
+            ast.Block(stats.flatMap(extractStmts) ++ extractStmts(expr).flatMap {
+              case ast.Block(stmts) => stmts
+              case s => List(s)
+            })
+
+          case Try(block, catches, finalizer) =>
+            ast.Try(wrapStatements(extractStmts(block)), catches.map { case c @ CaseDef(pat, guard, body) =>
+              val guarded = ast.Guarded(extractExpr(pat), extractExpr(guard)).setPos(extractPosition(c.pos))
+              val block = wrapStatements(extractStmts(body))
+              guarded -> block
+            }, wrapStatements(extractStmts(finalizer)))
+
+          case Function(vparams, body) =>
+            ast.FunctionLiteral(vparams.map(p => extractDef(p).asInstanceOf[ast.ValDef]), ast.Empty[ast.Type], extractExpr(body))
+
+          case Assign(left, right) =>
+            ast.Assign(extractExpr(left), extractExpr(right), None)
+
+          case If(cond, thenn, elsep) =>
+            ast.If(extractExpr(cond), extractExpr(thenn), extractExpr(elsep))
+
+          case Match(selector, cases) =>
+            ast.Switch(extractExpr(selector), cases.map { case c @ CaseDef(pat, guard, body) =>
+              val guarded = ast.Guarded(extractExpr(pat), extractExpr(guard)).setPos(extractPosition(c.pos))
+              val block = wrapStatements(extractStmts(body))
+              guarded -> block
+            })
+
+          case build.SyntacticFor(enums, body) => extractFors(enums, extractExpr(body), false)
+
+          case build.SyntacticForYield(enums, body) => extractFors(enums, extractExpr(body), true)
+
+          case Apply(fun, args) => extractExpr(fun) match {
+            case a @ ast.FieldAccess(receiver, name, tparams) =>
+              ast.FunctionCall(ast.FieldAccess(receiver, name, Nil).fromAST(a), tparams, args.map(extractExpr))
+            case n : ast.ConstructorCall => n.copy(args = n.args ++ args.map(extractExpr)).fromAST(n)
+            case caller => ast.FunctionCall(caller, Nil, args.map(extractExpr))
+          }
+
+          case TypeApply(fun, args) =>
+            val tpArgs = args.map(extractType)
+            extractExpr(fun) match {
+              case a : ast.FieldAccess => a.copy(tparams = a.tparams ++ tpArgs)
+              case n : ast.ConstructorCall => n.copy(tpe = n.tpe.copy(tparams = n.tpe.tparams ++ tpArgs).fromAST(n.tpe)).fromAST(n)
+              case caller => ast.FunctionCall(caller, tpArgs, Nil)
+            }
+
+          case Select(receiver, name) =>
+            ast.FieldAccess(extractExpr(receiver), name.decode, Nil)
+
+          case Super(qual, mix) =>
+            ast.Super(extractExpr(qual) match {
+              case ast.This(id) => id
+              case q => q
+            })
+
+          case This(qual) =>
+            ast.This(if (qual == tpnme.EMPTY) ast.Empty.NoExpr else ast.Ident(qual.decode).setPos(pos))
+
+          case Ident(name) =>
+            if (name == nme.WILDCARD) ast.Wildcard
+            else ast.Ident(name.decode)
+
+          case Bind(name, body) =>
+            ast.Bind(name.decode, extractExpr(body))
+
+          case Literal(c) if c.tag == UnitTag => ast.VoidLiteral
+
+          case Literal(c) if c.tag == NullTag => ast.NullLiteral
+
+          case Literal(c) => ast.SimpleLiteral(c.tag match {
+            case NoTag => ast.PrimitiveTypes.Special("no type")
+            case BooleanTag => ast.PrimitiveTypes.Boolean
+            case ByteTag => ast.PrimitiveTypes.Byte
+            case ShortTag => ast.PrimitiveTypes.Short
+            case CharTag => ast.PrimitiveTypes.Char
+            case IntTag => ast.PrimitiveTypes.Int
+            case LongTag => ast.PrimitiveTypes.Long
+            case FloatTag => ast.PrimitiveTypes.Float
+            case DoubleTag => ast.PrimitiveTypes.Double
+            case StringTag => ast.PrimitiveTypes.String
+            case ClazzTag => ast.PrimitiveTypes.Special("class")
+            case EnumTag => ast.PrimitiveTypes.Special("enum")
+          }, c.stringValue)
+
+          case New(tpt) => ast.ConstructorCall(extractType(tpt).asInstanceOf[ast.ClassType], Nil, Nil)
+
+          case Throw(expr) => ast.Throw(extractExpr(expr))
+
+          case Alternative(trees) => ast.MultiLiteral(trees.map(extractExpr))
+
+          case Annotated(annot, arg) =>
+            extractExpr(arg).appendComment(annot.toString)
+
+          case Typed(expr, tpt) =>
+            val bound @ ast.Bind(name, _) = extractExpr(expr) match {
+              case b: ast.Bind => b
+              case expr => ast.Bind(Names.DEFAULT, expr).setPos(expr.pos)
+            }
+            ast.Guarded(bound, ast.InstanceOf(ast.Ident(name).setPos(bound.pos), extractType(tpt)).setPos(bound.pos))
+
+          case Star(elem) => ast.UnaryOp(extractExpr(elem), "*", true)
+
+          // While loops can take place in expression positions in Scala
+          case ld: LabelDef => ast.Block(extractStmts(ld) :+ ast.VoidLiteral)
+
+          case EmptyTree => ast.Empty.NoExpr
+
+          case o => throw ParsingFailedError(new RuntimeException(s"Unknown expression tree [${o.getClass}]: $o"))
+        }
+
+        extracted.setPos(pos)
+      }
+
+      Normalizer(tree match {
+        case d: DefTree => extractDef(d)
+        case t: TermTree => extractStmts(t) match {
+          case List(x) => x
+          case Nil => ast.Empty[ast.Statement]
+          case list => ast.Block(list).setPos(extractPosition(tree.pos))
+        }
+        case t: TypTree => extractType(t)
+      })
+    }
+  }
+
+}

--- a/src/main/scala/devsearch/parsers/QueryParser.scala
+++ b/src/main/scala/devsearch/parsers/QueryParser.scala
@@ -34,15 +34,14 @@ object QueryParser extends Parser {
     case abort: scala.reflect.macros.runtime.AbortMacroException => throw ParsingFailedError(abort)
   }
 
-  private class QueryCompiler extends {
-    val c = new {
+  private class QueryCompiler extends Quasiquotes { self =>
+    object c extends {
       val universe: compiler.type = compiler
       val expandee = universe.EmptyTree
       val callsiteTyper = universe.analyzer.newTyper(universe.analyzer.NoContext)
     } with scala.reflect.macros.runtime.Context {
       val prefix = Expr[Nothing](universe.EmptyTree)(TypeTag.Nothing)
     }
-  } with Quasiquotes { self =>
 
     import global._
     import compat.{gen, build}

--- a/src/test/scala/devsearch/features/FeatureTestHelper.scala
+++ b/src/test/scala/devsearch/features/FeatureTestHelper.scala
@@ -5,7 +5,12 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.{SparkConf, SparkContext}
 
 object FeatureTestHelper {
-    val sc = new SparkContext(new SparkConf().setAppName("featureTest").setMaster("local[2]"))
+
+    // disable spark info-level logging during tests
+    // XXX: some INFO-level logs don't seem to want to disappear... Oh well...
+    org.apache.log4j.Logger.getLogger("org").setLevel(org.apache.log4j.Level.WARN)
+    org.apache.log4j.Logger.getLogger("akka").setLevel(org.apache.log4j.Level.WARN)
+
     val codeFileLocation = CodeFileLocation("unknown_repo", "unknown_user", "JavaConcepts.java")
 
     private def generateSingleCodeFileData(): CodeFileData = {
@@ -35,7 +40,12 @@ object FeatureTestHelper {
 //        matching(Traverser(List(_))(tree).toList)
 //    }
 
-    def getSampleCodeData(): RDD[CodeFileData] = {
-        sc.parallelize(List(generateSingleCodeFileData()))
+    def withSampleCodeData[T](f: RDD[CodeFileData] => T): T = {
+      val conf = new SparkConf().setAppName("featureTest").setMaster("local[2]")
+
+      val sc = new SparkContext(conf)
+      val res = f(sc.parallelize(List(generateSingleCodeFileData())))
+      sc.stop()
+      res
     }
 }

--- a/src/test/scala/devsearch/features/ImportExtractorTest.scala
+++ b/src/test/scala/devsearch/features/ImportExtractorTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.{FlatSpec}
 
 class ImportExtractorTest extends FlatSpec {
     "import extractor" should "extract all imports" in {
-        val sampleCodeData = FeatureTestHelper.getSampleCodeData()
+      FeatureTestHelper.withSampleCodeData { sampleCodeData =>
         val importFeatures = ImportExtractor.extract(sampleCodeData)
 
         assert(importFeatures.collect.toSet == Set(
@@ -16,5 +16,6 @@ class ImportExtractorTest extends FlatSpec {
                 ImportFeature(FeatureTestHelper.codeFileLocation, InFilePosition(3, 1), "com.github.javaparser.JavaParser", false, false)
             )
         )
+      }
     }
 }

--- a/src/test/scala/devsearch/features/InheritanceExtractorTest.scala
+++ b/src/test/scala/devsearch/features/InheritanceExtractorTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class InheritanceExtractorTest extends FlatSpec with Matchers {
     "inheritance extractor" should "extract all class extensions and interface implementations" in {
-        val codeFileData = FeatureTestHelper.getSampleCodeData()
+      FeatureTestHelper.withSampleCodeData { codeFileData =>
 
         val inheritanceFeatures = InheritanceExtractor.extract(codeFileData)
         assert(inheritanceFeatures.collect.toSet == Set(
@@ -18,5 +18,6 @@ class InheritanceExtractorTest extends FlatSpec with Matchers {
                 InheritanceFeature(FeatureTestHelper.codeFileLocation, InFilePosition(208, 208), "QWE", "JavaConcepts")
             )
         )
+      }
     }
 }

--- a/src/test/scala/devsearch/features/VariableDeclarationExtractorTest.scala
+++ b/src/test/scala/devsearch/features/VariableDeclarationExtractorTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.{Matchers, FlatSpec}
 
 class VariableDeclarationExtractorTest extends FlatSpec with Matchers {
     "variable declaration extractor" should "extract all variable declarations" in {
-        val codeFileData = FeatureTestHelper.getSampleCodeData()
+      FeatureTestHelper.withSampleCodeData { codeFileData =>
 
         val variableDeclarationFeatures = VariableDeclarationExtractor.extract(codeFileData)
         // TODO(julien, mateusz): add a test for each type name
@@ -15,5 +15,6 @@ class VariableDeclarationExtractorTest extends FlatSpec with Matchers {
                 VariableDeclarationFeature(FeatureTestHelper.codeFileLocation, InFilePosition(109,18), "Array[Array[devsearch.ast.PrimitiveTypes.Int$]]", "arr4")
             ).subsetOf(variableDeclarationFeatures.collect.toSet)
         )
+      }
     }
 }

--- a/src/test/scala/devsearch/parsers/GoParserTest.scala
+++ b/src/test/scala/devsearch/parsers/GoParserTest.scala
@@ -48,7 +48,7 @@ class GoParserTest extends FlatSpec with Matchers {
     val ast = GoParser.parse(source)
     val name = ast match {
       case p : PackageDef => p.name
-      case _ => Names.default
+      case _ => Names.DEFAULT
     }
 
     assert(ast == PackageDef(name,List(),
@@ -99,7 +99,7 @@ class GoParserTest extends FlatSpec with Matchers {
     val ast = GoParser.parse(source)
     val name = ast match {
       case p : PackageDef => p.name
-      case _ => Names.default
+      case _ => Names.DEFAULT
     }
 
     assert(ast == PackageDef(name,List(),
@@ -158,7 +158,7 @@ class GoParserTest extends FlatSpec with Matchers {
     val ast = GoParser.parse(source)
     val name = ast match {
       case p : PackageDef => p.name
-      case _ => Names.default
+      case _ => Names.DEFAULT
     }
 
     assert(ast == PackageDef(name,List(),List(Import("fmt",false,false)),List(

--- a/src/test/scala/devsearch/parsers/JavaParserTest.scala
+++ b/src/test/scala/devsearch/parsers/JavaParserTest.scala
@@ -21,11 +21,11 @@ class JavaParserTest extends FlatSpec with Matchers {
       }
     """)
 
-    assert(JavaParser.parse(source) == PackageDef(Names.default, Nil, Nil, List(
+    assert(JavaParser.parse(source) == PackageDef(Names.DEFAULT, Nil, Nil, List(
       ClassDef(NoModifiers, "ClassWithAConstructor", Nil, Nil, Nil, List(
-        ConstructorDef(PROTECTED, "ClassWithAConstructor",
+        ConstructorDef(PROTECTED,
           List("This", "AndThat", "AndWhatElse").map { s =>
-            Annotation(Names.THROWS_ANNOTATION, Map(Names.default -> Ident(s)))
+            Annotation(Names.THROWS_ANNOTATION, Map(Names.DEFAULT -> Ident(s)))
           }, Nil, List(
             ValDef(NoModifiers, "a", Nil, PrimitiveTypes.Int, Empty[Expr]),
             ValDef(NoModifiers, "b", Nil, PrimitiveTypes.String, Empty[Expr])
@@ -86,7 +86,7 @@ class JavaParserTest extends FlatSpec with Matchers {
       }
     """)
 
-    assert(JavaParser.parse(source) ==  PackageDef(Names.default,List(),List(),List(
+    assert(JavaParser.parse(source) ==  PackageDef(Names.DEFAULT,List(),List(),List(
       ClassDef(NoModifiers,"Test",List(),List(),List(),List(
         FunctionDef(PUBLIC,"toto",List(),List(),List(ValDef(NoModifiers,"i",List(),PrimitiveTypes.Int,NoExpr,false)),PrimitiveTypes.Void,Block(List(
           Switch(Ident("i"),List(
@@ -99,5 +99,20 @@ class JavaParserTest extends FlatSpec with Matchers {
             (SimpleLiteral(PrimitiveTypes.Int,"3"),Block(List(
               FunctionCall(FieldAccess(FieldAccess(Ident("System"),"out",List()),"println",List()),List(),List(SimpleLiteral(PrimitiveTypes.String,"3")))))),
             (NoExpr,NoStmt))))))),ClassSort))))
+  }
+
+  it should "work without enclosing class" in {
+    val source = new ContentsSource("Something.java", """
+      public void doSomething(int i) {
+        return i + 2;
+      }
+    """)
+
+    assert(JavaParser.parse(source) == PackageDef(Names.DEFAULT,List(),List(),List(
+      ClassDef(NoModifiers,Names.DEFAULT,List(),List(),List(),List(
+        FunctionDef(PUBLIC,"doSomething",List(),List(),
+          List(ValDef(NoModifiers,"i",List(),PrimitiveTypes.Int,NoExpr,false)),PrimitiveTypes.Void,
+          Block(List(Return(BinaryOp(Ident("i"),"+",SimpleLiteral(PrimitiveTypes.Int,"2"))))))
+      ),ClassSort))))
   }
 }

--- a/src/test/scala/devsearch/parsers/QueryParserTest.scala
+++ b/src/test/scala/devsearch/parsers/QueryParserTest.scala
@@ -1,0 +1,145 @@
+package devsearch.parsers
+
+import org.scalatest._
+import devsearch.ast._
+import devsearch.ast.Empty._
+import devsearch.ast.Modifiers._
+
+class QueryParserTest extends FlatSpec with Matchers {
+
+  "Query language" should "be parsable" in {
+    val source = new ContentsSource("Test.scala", """
+      def a = 2
+      def $_ = 1
+      def _ = 1
+
+      def toto(_) = 1
+
+      case class Toto(a: Int, b: Int)
+      val t @ Toto(a,b) = Toto(1,2)
+
+      for (i <- List.range(1,2)) yield i
+
+      for (i <- List.range(1,2);
+           a = 2;
+           _ <- toto;
+           e <- List.range(3,4)) yield i + e + a
+    """)
+
+    QueryParser.parse(source)
+  }
+
+  it should "parse for comprehensions" in {
+    val source = new ContentsSource("NoFile", """
+      for (i <- List.range(1,2);
+           a = 2;
+           _ <- toto;
+           e <- List.range(3,4)) yield i + e + a
+    """)
+
+    assert(QueryParser.parse(source) == Block(List(
+      Foreach(
+        List(ValDef(FINAL,"i",List(),NoType,NoExpr,false)),
+        FunctionCall(
+          FieldAccess(Ident("List"),"range",List()),List(),List(
+            SimpleLiteral(PrimitiveTypes.Int,"1"),
+            SimpleLiteral(PrimitiveTypes.Int,"2")
+          )),Block(List(
+            ValDef(FINAL,"a",List(),NoType,SimpleLiteral(PrimitiveTypes.Int,"2"),false),
+            Foreach(
+              List(ValDef(FINAL,"_",List(),NoType,NoExpr,false)),
+              Ident("toto"),
+              Foreach(
+                List(ValDef(FINAL,"e",List(),NoType,NoExpr,false)),
+                FunctionCall(FieldAccess(Ident("List"),"range",List()),List(),List(
+                  SimpleLiteral(PrimitiveTypes.Int,"3"),
+                  SimpleLiteral(PrimitiveTypes.Int,"4")
+                )), BinaryOp(BinaryOp(Ident("i"),"+",Ident("e")),"+",Ident("a")),true),true))),true))))
+  }
+
+  it should "parse varArgs" in {
+    val source = new ContentsSource("NoFile", """
+      def test(a: String*)
+    """)
+
+    assert(QueryParser.parse(source) == Block(List(
+      FunctionDef(FINAL | ABSTRACT,"test",List(),List(),
+        List(ValDef(FINAL,"a",List(),PrimitiveTypes.String,NoExpr,true)),
+        PrimitiveTypes.Void, NoStmt))))
+  }
+
+  it should "parse primitive types" in {
+    val source = new ContentsSource("NoFile", """
+      val a = 1
+      val b: Int = 2
+      def toto(f: Int => Int) = f(2)
+    """)
+
+    assert(QueryParser.parse(source) == Block(List(
+      ValDef(FINAL,"a",List(),NoType,SimpleLiteral(PrimitiveTypes.Int,"1"),false),
+      ValDef(FINAL,"b",List(),PrimitiveTypes.Int,SimpleLiteral(PrimitiveTypes.Int,"2"),false),
+      FunctionDef(FINAL,"toto",List(),List(),List(
+        ValDef(FINAL,"f",List(),FunctionType(List(PrimitiveTypes.Int), PrimitiveTypes.Int), NoExpr,false)
+      ),NoType,Block(List(
+        FunctionCall(Ident("f"),List(),List(SimpleLiteral(PrimitiveTypes.Int,"2")))))),
+      VoidLiteral)))
+  }
+
+  it should "parse null literal" in {
+    val source = new ContentsSource("NoFile", "val a = null")
+
+    assert(QueryParser.parse(source) == Block(List(ValDef(FINAL,"a",List(),NoType,NullLiteral,false))))
+  }
+
+  it should "parse loops" in {
+    val source = new ContentsSource("NoFile", """
+      while (a < 0) {
+        a += 1
+        println(a)
+      }
+    """)
+
+    assert(QueryParser.parse(source) == Block(List(
+      While(BinaryOp(Ident("a"),"<",SimpleLiteral(PrimitiveTypes.Int,"0")),
+        Block(List(
+          Assign(Ident("a"),SimpleLiteral(PrimitiveTypes.Int,"1"), Some("+")),
+          FunctionCall(Ident("println"),List(),List(Ident("a")))))))))
+  }
+
+  it should "parse expression loops" in {
+    val source = new ContentsSource("NoFile", """
+      val a = while(b < 0) {
+        b += 1
+      }
+    """)
+
+    assert(QueryParser.parse(source) == Block(List(
+      ValDef(FINAL,"a",List(),NoType,Block(List(
+        While(BinaryOp(Ident("b"),"<",SimpleLiteral(PrimitiveTypes.Int,"0")),
+          Block(List(Assign(Ident("b"),SimpleLiteral(PrimitiveTypes.Int,"1"),Some("+"))))),
+        VoidLiteral)),false))))
+  }
+
+  it should "parse do-while statements" in {
+    val source = new ContentsSource("NoFile", """
+      do {
+        println(a.next)
+      } while (a.hasNext)
+    """)
+
+    assert(QueryParser.parse(source) == Block(List(
+      Do(FieldAccess(Ident("a"),"hasNext",List()),
+        Block(List(FunctionCall(Ident("println"),List(),List(FieldAccess(Ident("a"),"next",List())))))))))
+  }
+
+  /*
+  it should "be robust" in {
+    val source = new ContentsSource("NoFile", """
+      def test(a: Int) = {
+        a + 1
+    """)
+
+    println(QueryParser.parse(source))
+  }
+      */
+}

--- a/src/test/scala/devsearch/parsers/QueryParserTest.scala
+++ b/src/test/scala/devsearch/parsers/QueryParserTest.scala
@@ -132,6 +132,25 @@ class QueryParserTest extends FlatSpec with Matchers {
         Block(List(FunctionCall(Ident("println"),List(),List(FieldAccess(Ident("a"),"next",List())))))))))
   }
 
+  it should "work for named arguments" in {
+    val source = new ContentsSource("NoFile", "test(a = 1, b = 2)")
+
+    assert(QueryParser.parse(source) == Block(List(
+      FunctionCall(Ident("test"),List(),List(
+        Assign(Ident("a"),SimpleLiteral(PrimitiveTypes.Int,"1"),None),
+        Assign(Ident("b"),SimpleLiteral(PrimitiveTypes.Int,"2"),None))))))
+  }
+
+  it should "work for annotations" in {
+    val source = new ContentsSource("NoFile", "@annot(a = 1, b = 2) val a = 1")
+
+    assert(QueryParser.parse(source) == Block(List(
+      ValDef(FINAL,"a",List(Annotation("annot",Map(
+        "a" -> SimpleLiteral(PrimitiveTypes.Int,"1"),
+        "b" -> SimpleLiteral(PrimitiveTypes.Int,"2")
+      ))),NoType,SimpleLiteral(PrimitiveTypes.Int,"1"),false))))
+  }
+
   /*
   it should "be robust" in {
     val source = new ContentsSource("NoFile", """

--- a/src/test/scala/devsearch/parsers/ScalaParserTest.scala
+++ b/src/test/scala/devsearch/parsers/ScalaParserTest.scala
@@ -1,0 +1,1002 @@
+package devsearch.parsers
+
+import org.scalatest._
+import devsearch.ast._
+import devsearch.ast.Empty._
+
+class ScalaParserTest extends FunSuite with Matchers {
+
+  var counter = 0
+
+  def testCode(body: => Unit): Unit = {
+    counter += 1
+    test(s"Test #$counter")(body)
+  }
+
+  def checkNeg[T](input: String) = testCode {
+    val source = new ContentsSource("NoFile", input)
+    try {
+      val result = QueryParser.parse(source)
+      if (result != NoDef) throw new RuntimeException("failed!")
+    } catch {
+      case pf: ParsingFailedError =>
+    }
+  }
+
+  def check[T](input: String, tag: String = "") = testCode {
+    val source = new ContentsSource("NoFile", input)
+    QueryParser.parse(source)
+  }
+
+  check(
+    "package torimatomeru"
+  )
+
+  check(
+    """package torimatomeru
+      |
+      |package lols
+    """.stripMargin
+  )
+
+  /* WRONG TEST!!
+  check(
+    """package torimatomeru
+      |import a
+      |import b
+    """.stripMargin
+  )
+  */
+
+  check(
+    """
+      |package torimatomeru
+      |
+      |import org.parboiled2.ParseError
+      |import utest._
+      |import utest.framework.Test
+      |import utest.util.Tree
+      |
+      |import scala.util.{Failure, Success}
+      |
+      |object SyntaxTest extends TestSuite
+    """.stripMargin
+  )
+  check(
+    """
+      |object SyntaxTest extends TestSuite{
+      |  def check[T](input: String) = {
+      |
+      |  }
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object SyntaxTest{
+      |  a()
+      |  throw 1
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object SyntaxTest extends TestSuite{
+      |  {
+      |        println
+      |        throw 1
+      |  }
+      |}
+    """.stripMargin
+  )
+  check(
+    """package scalatex
+      |
+      |
+      |import org.parboiled2._
+      |import torimatomeru.ScalaSyntax
+      |
+      |import scalatex.stages.{Trim, Parser, Ast}
+      |import scalatex.stages.Ast.Block.{IfElse, For, Text}
+      |import Ast.Chain.Args
+      |
+      |object ParserTests extends utest.TestSuite{
+      |  import Ast._
+      |  import utest._
+      |  def check[T](input: String, parse: Parser => scala.util.Try[T], expected: T) = {
+      |    val parsed = parse(new Parser(input)).get
+      |    assert(parsed == expected)
+      |  }
+      |  def tests = TestSuite{}
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object Moo{
+      |  a
+      |  .b
+      |
+      |  c
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object Moo{
+      | filename
+      |        .asInstanceOf[Literal]
+      |10
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object Cow{
+      |  ().mkString
+      |
+      |  1
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object O{
+      | private[this] val applyMacroFull = 1
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object O{
+      | private[this] def applyMacroFull(c: Context)
+      |                      (expr: c.Expr[String],
+      |                       runtimeErrors: Boolean,
+      |                       debug: Boolean)
+      |                      : c.Expr[Frag] = {
+      |                      }
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object O{
+      |  class DebugFailure extends Exception
+      |
+      |  1
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |package torimatomeru
+      |
+      |package syntax
+      |
+      |import org.parboiled2._
+      |
+    """.stripMargin
+  )
+  check(
+    """
+      |object Foo{
+      |  0 match {
+      |    case A | B => 0
+      |  }
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+    |object Compiler{
+    |
+    |  def apply = {
+    |    def rec = t match {
+    |      case 0 => 0
+    |    }
+    |
+    |    rec(tree)
+    |  }
+    |}
+    |
+  """.
+      stripMargin
+  )
+  check(
+    """
+      |object O {
+      |    A(A(A(A(A(A(A(A())))))))
+      |}
+      |
+    """.stripMargin
+  )
+  check(
+    """
+      |object O{
+      |   A(A(A(A(A(A(A(A(A(A(A(A(A(A(A(A())))))))))))))))
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object L{
+      |  a.b = c
+      |  a().b = c
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object L{
+      |  a b c
+      |  d = 1
+      |}
+    """.stripMargin
+  )
+
+  check(
+    """/*                     __                                               *\
+      |**     ________ ___   / /  ___      __ ____  Scala.js CLI               **
+      |**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
+      |**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+      |** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+      |**                          |/____/                                     **
+      |\*                                                                      */
+      |
+      |package scala.scalajs.cli
+      |
+    """.stripMargin
+  )
+  check(
+    """
+      |object O{
+      |  for {
+      |      a  <- b
+      |      c <- d
+      |  } {
+      |    1
+      |  }
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object O{
+      |  val jarFile =
+      |      try { 1 }
+      |      catch { case _: F => G }
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object F{
+      |  func{ case _: F => fail }
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object Foo{
+      |    val a = d // g
+      |    val b = e // h
+      |    val c = f
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object L{
+      |  x match{
+      |    case y.Y(z) => z
+      |  }
+      |}
+    """.stripMargin
+  )
+  check(
+    """object K{
+      |  val a: B {
+      |    val c: D
+      |  }
+      |
+      |  1
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object LOLS{
+      |    def run() {}
+      |
+      |    def apply() {}
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object O{
+      |  a =:= b.c
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object K{
+      |  a(
+      |    1: _*
+      |  )
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object P{
+      |      tree match {
+      |        case stats :+ expr  => 1
+      |      }
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object K{
+      |  val trueA = 1
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object K{
+      |  val nullo :: cow = 1
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object K{
+      |  val omg_+ = 1
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object K{
+      |  val + = 1
+      |  var * = 2
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object O{
+      |  c match {
+      |    case b_  => 1
+      |  }
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |trait Basic {
+      |  b match {
+      |    case C => true; case _ => false
+      |  }
+      |}
+    """.stripMargin
+  )
+  check(
+    """trait Basic {
+      |  !a.b
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |class Parser {
+      |  {() => }
+      |}
+      |
+    """.stripMargin
+  )
+  check(
+    """
+      |
+      |
+      |
+      |package omg
+      |;
+      |
+      |;
+      |
+      |;
+      |class Parser
+      |;
+      |
+      |;
+      |
+      |;
+    """.stripMargin
+  )
+  check(
+    """
+      |
+      |object GenJSCode {
+      |  code: @switch
+      |}
+    """.stripMargin
+  )
+  check(
+    """object B {
+      |  { a: L => }
+      |}
+    """.stripMargin
+  )
+  check(
+    """object O{
+      |  {
+      |    val index = 0
+      |    i: Int => 10
+      |    0
+      |  }
+      |}
+    """.stripMargin
+  )
+  check(
+    """object GenJSCode{
+      |  val g: G.this.g.type
+      |}
+      |
+    """.stripMargin
+  )
+  check(
+    """object K{
+      |  class RTTypeTest
+      |  private object O
+      |}
+    """.stripMargin
+  )
+  check(
+    """object O{
+      |  if (eqeq &&
+      |
+      |    false)  1
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object O{
+      |  for(
+      |    x <- Nil map
+      |
+      |  (x => x)
+      |  ) yield x
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object O{
+      |  for{
+      |    x <- Nil
+      |    if
+      |
+      |    1 == 2
+      |  } yield x
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      |object ScopedVar {
+      |  def withScopedVars(ass: Seq[_]) = 1
+      |}
+      |
+    """.stripMargin
+  )
+  check(
+    """
+      |object VarArgs {
+      |  def test(a: String*) = println(a.toSeq)
+      |}
+      |
+    """.stripMargin
+  )
+  check(
+    """
+      |abstract class JSASTTest extends DirectTest {
+      |  def show: this.type = ()
+      |}
+      |
+    """.stripMargin
+  )
+  check(
+    """object Traversers {
+      |  {
+      |        1
+      |        cases foreach nil
+      |  }
+      |}
+    """.stripMargin
+  )
+  check(
+    """object Utils {
+      |  "\\"
+      |}
+      |
+    """.stripMargin
+  )
+  check(
+    """object F{
+      |  this eq that.asInstanceOf[AnyRef]
+      |}
+    """.stripMargin
+  )
+  check(
+    """class C{
+      |  0x00 <= 2 && 1
+      |}
+      |
+    """.stripMargin
+  )
+  check(
+    """class Runtime private
+    """.stripMargin
+  )
+  check(
+    """
+      |object System {
+      |  def a[@b T[@b V]] = 1
+      |}
+      |
+    """.stripMargin
+  )
+  check(
+    """object U{
+      |  private val _fragment = fld(Fragment)
+      |  _fld = null
+      |}
+    """.stripMargin
+  )
+  check(
+    """class Array{
+      |  def length_= = 1
+      |}
+    """.stripMargin
+  )
+  check(
+    """object K{
+      |  def newBuilder =
+      |    new B
+      |
+      |  @inline def a = 1
+      |}
+    """.stripMargin
+  )
+  check(
+    """trait Function12[-T1, +R]
+    """.stripMargin
+  )
+  check(
+    """@a // Don't do this at home!
+      |trait B
+    """.stripMargin
+  )
+  check(
+    """object T{
+      |  type B = { def F: S }
+      |}
+      |
+    """.stripMargin
+  )
+  check(
+    """
+      |object ScalaJSBuild{
+      |      (
+      |        1 / 2
+      |          / 3
+      |      )
+      |}
+      |
+    """.stripMargin
+  )
+  check(
+    """trait Writer{
+      | '\f'
+      |}
+    """.stripMargin
+  )
+  check(
+    """object CyclicDependencyException {
+      |    def str(info: ResolutionInfo) =
+      |      s"${info.resourceName} from: ${info.origins.mkString(", ")}"
+      |}
+    """.stripMargin
+  )
+  check(
+    """object OptimizerCore {
+      |  tpe match {
+      |    case NothingType | _:RecordType=> 1
+      |  }
+      |}
+    """.stripMargin
+  )
+  check(
+    """class A{
+      |  1
+      |  () => 1
+      |}
+    """.stripMargin
+  )
+  check(
+    """trait ReactorCanReply {
+      |  _: InternalReplyReactor =>
+      |}
+    """.stripMargin
+  )
+
+  check(
+    """object G{
+      |  def isBefore(pd: SubComponent) = settings.stopBefore
+      |  phaseDescriptors sliding 2 collectFirst ()
+      |}
+    """.stripMargin
+  )
+  check(
+    """class SymbolLoaders {
+      |  type T = ClassPath[AbstractFile]#ClassRep
+      |}
+    """.stripMargin
+  )
+  check(
+    """trait ContextErrors {
+      |    def isUnaffiliatedExpr = expanded.isInstanceOf[scala.reflect.api.Exprs#Expr[_]]
+      |}
+    """.stripMargin
+  )
+  check(
+    """trait Typers{
+      |  s"nested ${ if (1) "trait" else "class" }"
+      |}
+    """.stripMargin
+  )
+  check(
+    """trait ReflectSetup { this: Global =>
+      |  phase = 1
+      |}
+    """.stripMargin
+  )
+  check(
+    """trait Predef {
+      |  @x
+      |  // a
+      |  type T
+      |}
+    """.stripMargin
+  )
+  check(
+    """
+      object StringContext {
+
+        s"${
+          require(index >= 0 && index < str.length)
+          val ok = "[\b, \t, \n, \f, \r, \\, \", \']"
+          if (index == str.length - 1) "at terminal" else s"'\\${str(index + 1)}' not one of $ok at"
+        }"
+
+      }
+    """.stripMargin
+  )
+  check(
+    """trait Growable {
+      |    +=
+      |}
+    """.stripMargin
+  )
+  check(
+    """package immutable {
+      |  object O
+      |}
+    """.stripMargin
+  )
+  check(
+    """import java.util.concurrent.TimeUnit.{ NANOSECONDS => NANOS, MILLISECONDS ⇒ MILLIS }
+    """.stripMargin
+  )
+  check(
+    """class FunFinder{
+      |  val targetName = s"$name${ if (isModule) "$" else "" }"
+      |}
+    """.stripMargin
+  )
+  check(
+    """class AkkaException{
+      |  for (i ← 0 until trace.length)
+      |    ()
+      |}
+    """.stripMargin
+  )
+  check(
+    """object Test4 {
+      |    type T = F @field
+      |    @BeanProperty val x = 1
+      |}
+    """.stripMargin
+  )
+  check(
+    """package `dmacro` {
+      |}
+    """.stripMargin
+  )
+  check(
+    """class A {
+      |  def fn1 = List apply 1
+      |  def fn2 = List apply[Int] 2
+      |}
+    """.stripMargin
+  )
+  check(
+    """class C {
+      |  def this(x: Int) = {
+      |    this();
+      |    class D;
+      |  }
+      |}
+    """.stripMargin
+  )
+  check(
+    """trait B[T] {
+      |  def f1(a: T): Unit { }
+      |}
+    """.stripMargin
+  )
+  check(
+    """object test {
+      |  case object Int16 extends SampleFormat1
+      |  (1) match {
+      |    case _   => 1
+      |  }
+      |}
+    """.stripMargin
+  )
+  check(
+    """object A {
+      |  def x {
+      |    implicit lazy val e: Int = 0
+      |  }
+      |}
+    """.stripMargin
+  )
+  check(
+    """object test {
+      |  for {
+      |    n <- A
+      |    a <- B
+      |    _ <- C
+      |  } yield n
+      |}
+    """.stripMargin
+  )
+//      check(
+//        """object Test {
+//          |  def t1: M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[M[Inty @unchecked]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]] = x
+//          |}
+//        """.stripMargin
+//      )
+  check(
+    """abstract class Mix___eFoo___wBar_I_ extends Foo___ with Bar_I_    { ; ; f; }
+    """.stripMargin
+  )
+  check(
+    """package test2 {
+      |object N1M0;
+      |}
+    """.stripMargin
+  )
+  check(
+    """class IP extends {
+      |  val baz = "bar";
+      |} with Foo(() => baz);
+    """.stripMargin
+  )
+  check(
+    """object Test extends App {
+      |  val x: C {} = 1
+      |}
+    """.stripMargin
+  )
+  check(
+    """trait LensFunctions {
+      |  type T = A @> B
+      |}
+    """.stripMargin
+  )
+  check(
+    """object ContravariantCoyonedaUsage {
+      |  (schwartzian[Vector[String], ccord.I]
+      |      (unstructuredData)(v => ccord.k(v(i)))(ccord.fi))
+      |}
+    """.stripMargin
+  )
+  check(
+    """object MapTest{
+      |  forAll { a: Int ==>> Int =>
+      |  }
+      |}
+    """.stripMargin
+  )
+  check(
+    """object Test {
+      |  def countingDownActor = {
+      |    val ms = 1
+      |    (m: Int) =>
+      |      val x = 1
+      |      1
+      |  }
+      |}
+    """.stripMargin
+  )
+  check(
+    """object X{
+      |  type T = {
+      |    ;;;
+      |    type x = Int
+      |    ;;;
+      |    type y = Int
+      |    ;;;
+      |  }
+      |}
+    """.stripMargin
+  )
+  check(
+    """object X{
+      |  <div />
+      |}
+    """.stripMargin
+  )
+  check(
+    """object X{
+      |  <div id="hello" />
+      |}
+    """.stripMargin
+  )
+  check(
+    """object X{
+      |  <url>https://github.com/lihaoyi/scalatags</url>
+      |}
+    """.stripMargin
+  )
+  check(
+    """object X{
+      |  <url>{ ;;;1 + 1 }</url>
+      |}
+    """.stripMargin
+  )
+  check(
+    """object UserAgentCalculator extends Factory {
+      |    for {
+      |      userAgent <- userAgent
+      |      findResult = ieMatch.find if findResult
+      |    } yield ver
+      |}
+    """.stripMargin
+  )
+//      check(
+//        """class FunctionalBuilder{
+//          |  a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a1, a2), a3), a4), a5), a6), a7), a8), a9), a10), a11), a12), a13), a14), a15), a16), a17), a18), a19), a20), a21), a22)
+//          |}
+//        """.stripMargin
+//      )
+  check(
+    """class HtmlPage {
+      |  <meta http-equiv="content-type" content={ 1 }/>
+      |}
+    """.stripMargin
+  )
+  check(
+    """object K{
+      |  <script> {{</script>
+      |}
+    """.stripMargin
+  )
+  check(
+    """object O{
+      |  e match { case <title>{ _* }</title> => }
+      |}
+      |
+    """.stripMargin
+  )
+  check(
+    """object Publish {
+      |  val x =
+      |    <inceptionYear>2009</inceptionYear>
+      |
+      |
+      |
+      |      <scm>
+      |        <url>git://github.com/akka/akka.git</url>
+      |        <connection>scm:git:git@github.com:akka/akka.git</connection>
+      |      </scm>
+      |}
+    """.stripMargin
+  )
+  check(
+    """object K{
+      |    <foo baz="&amp;dog"/>
+      |}
+    """.stripMargin
+  )
+  check(
+    """object X{
+      |   pomExtra :=
+      |      <url>https://github.com/lihaoyi/scalatags</url>
+      |        <licenses>
+      |          <license>
+      |            <name>MIT license</name>
+      |            <url>http://www.opensource.org/licenses/mit-license.php</url>
+      |          </license>
+      |        </licenses>
+      |        <scm>
+      |          <url>git://github.com/lihaoyi/scalatags.git</url>
+      |          <connection>scm:git://github.com/lihaoyi/scalatags.git</connection>
+      |        </scm>
+      |        <developers>
+      |          <developer>
+      |            <id>lihaoyi</id>
+      |            <name>Li Haoyi</name>
+      |            <url>https://github.com/lihaoyi</url>
+      |          </developer>
+      |        </developers>
+      |}
+    """.stripMargin
+  )
+  check(
+  """object X{
+    |  // parses as ~?>.$(1)
+    |  ~?>$ 1
+    |}
+  """.stripMargin
+  )
+
+  checkNeg(
+    """
+      |object O{
+      |  for{
+      |    x <- Nil map
+      |
+      |  (x => x)
+      |  } yield x
+      |}
+    """.stripMargin
+  )
+  checkNeg(
+    """object O{
+      |  for{
+      |    x <- Nil
+      |    if 1 ==
+      |
+      |    2
+      |  } yield x
+      |}
+    """.stripMargin
+  )
+  checkNeg(
+    """object O{
+      |  for{
+      |    x <- Nil
+      |    _ = 1 ==
+      |
+      |    2
+      |  } yield x
+      |}
+    """.stripMargin
+  )
+  checkNeg(
+    """
+      |object System {
+      |  def a[@b T[V @b]] = 1
+      |}
+      |
+    """.stripMargin
+  )
+}


### PR DESCRIPTION
The query language is basically Scala with a bit more flexibility based on quasiquotes (you can leave holes anywhere quasiquotes can have extractors).

The trees had to change a little to work with functional languages and there are still a few normalizations that would be good to add (see [Normalizer](https://github.com/devsearch-epfl/devsearch-ast/compare/feature/query-parser?expand=1#diff-1bc70c856e0cb31870d4799795d7d2d6R425)).

The query language has added robustness to missing braces and parentheses so even unclosed snippets (in Scala) should be parsable.